### PR TITLE
Add tests for array object manipulation

### DIFF
--- a/test/resonant.test.js
+++ b/test/resonant.test.js
@@ -59,3 +59,48 @@ test('array push updates data and triggers callback', async () => {
   assert.strictEqual(context.items.length, 3);
   assert.deepStrictEqual(callbackResult, { newVal: context.items, item: 3, action: 'added' });
 });
+
+test('push object into array and trigger callback', async () => {
+  const { context, resonant } = createResonant();
+  let callbackResult;
+  resonant.add('items', []);
+  resonant.addCallback('items', (newVal, item, action) => {
+    callbackResult = { newVal, item, action };
+  });
+  const obj = { id: 1, name: 'test' };
+  context.items.push(obj);
+  await new Promise(r => setTimeout(r, 5));
+  assert.strictEqual(resonant.data.items.length, 1);
+  assert.strictEqual(context.items[0].name, 'test');
+  assert.deepStrictEqual(callbackResult, { newVal: context.items, item: obj, action: 'added' });
+});
+
+test('edit object property in array', async () => {
+  const { context, resonant } = createResonant();
+  let callbackResult;
+  const obj = { id: 1, name: 'test' };
+  resonant.add('items', [obj]);
+  resonant.addCallback('items', (newVal, item, action) => {
+    callbackResult = { newVal, item, action };
+  });
+  context.items[0].name = 'updated';
+  await new Promise(r => setTimeout(r, 5));
+  assert.strictEqual(resonant.data.items[0].name, 'updated');
+  assert.deepStrictEqual(callbackResult, { newVal: context.items, item: context.items[0], action: 'modified' });
+});
+
+test('remove object from array', async () => {
+  const { context, resonant } = createResonant();
+  let callbackResult;
+  const obj1 = { id: 1 };
+  const obj2 = { id: 2 };
+  resonant.add('items', [obj1, obj2]);
+  resonant.addCallback('items', (newVal, item, action) => {
+    callbackResult = { newVal, item, action };
+  });
+  context.items.delete(0);
+  await new Promise(r => setTimeout(r, 5));
+  assert.strictEqual(resonant.data.items.length, 1);
+  assert.strictEqual(resonant.data.items[0].id, 2);
+  assert.deepStrictEqual(callbackResult, { newVal: context.items, item: obj1, action: 'removed' });
+});


### PR DESCRIPTION
## Summary
- extend array tests
- add tests for pushing objects, editing them and removing them

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f825ab8348327aa4079bc25e30795