### PR TITLE
Expand test coverage

### DIFF
--- a/test/resonant.test.js
+++ b/test/resonant.test.js
@@ -9,11 +9,18 @@ function createResonant() {
   const context = { console, setTimeout, clearTimeout };
   context.window = context;
   context.document = { querySelectorAll: () => [] };
-  context.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+
+  const store = {};
+  context.localStorage = {
+    getItem: key => (key in store ? store[key] : null),
+    setItem: (key, val) => { store[key] = val; },
+    removeItem: key => { delete store[key]; }
+  };
+
   vm.createContext(context);
   vm.runInContext(code, context);
   const Resonant = vm.runInContext('Resonant', context);
-  return { context, resonant: new Resonant() };
+  return { context, resonant: new Resonant(), store };
 }
 
 test('single variable updates global and data', () => {
@@ -103,4 +110,56 @@ test('remove object from array', async () => {
   assert.strictEqual(resonant.data.items.length, 1);
   assert.strictEqual(resonant.data.items[0].id, 2);
   assert.deepStrictEqual(callbackResult, { newVal: context.items, item: obj1, action: 'removed' });
+});
+
+test('variable is undefined before add and defined after', () => {
+  const { context, resonant } = createResonant();
+  assert.strictEqual(context.counter, undefined);
+  resonant.add('counter', 1);
+  assert.strictEqual(context.counter, 1);
+  assert.strictEqual(resonant.data.counter, 1);
+});
+
+test('addAll initializes multiple variables', () => {
+  const { context, resonant } = createResonant();
+  resonant.addAll({ first: 'a', second: 2 });
+  assert.strictEqual(context.first, 'a');
+  assert.strictEqual(context.second, 2);
+  assert.strictEqual(resonant.data.first, 'a');
+  assert.strictEqual(resonant.data.second, 2);
+});
+
+test('persist retrieves stored value and saves updates', async () => {
+  const { context, resonant, store } = createResonant();
+  store['res_count'] = JSON.stringify(5);
+  resonant.add('count', 0, true);
+  assert.strictEqual(context.count, 5);
+  context.count = 10;
+  await new Promise(r => setTimeout(r, 5));
+  assert.strictEqual(store['res_count'], JSON.stringify(10));
+});
+
+test('array update replaces array and triggers callback', async () => {
+  const { context, resonant } = createResonant();
+  let result;
+  resonant.add('nums', [1, 2]);
+  resonant.addCallback('nums', (newVal, item, action) => {
+    result = { newVal, item, action };
+  });
+  context.nums.update([3, 4]);
+  await new Promise(r => setTimeout(r, 5));
+  assert.deepStrictEqual(Array.from(context.nums), [3, 4]);
+  assert.deepStrictEqual(Array.from(resonant.data.nums), [3, 4]);
+  assert.deepStrictEqual(result, { newVal: context.nums, item: [3, 4], action: 'updated' });
+});
+
+test('filter does not modify array but triggers callback', async () => {
+  const { context, resonant } = createResonant();
+  let result;
+  resonant.add('vals', [1, 2, 3]);
+  resonant.addCallback('vals', (newVal, item, action) => { result = { newVal, item, action }; });
+  const filtered = context.vals.filter(v => v > 1);
+  await new Promise(r => setTimeout(r, 5));
+  assert.deepStrictEqual(Array.from(filtered), [2, 3]);
+  assert.deepStrictEqual(result, { newVal: context.vals, item: undefined, action: 'filtered' });
 });


### PR DESCRIPTION
## Summary
- enhance `createResonant` test helper with localStorage mock
- add new tests for initialization, `addAll`, persistence, array updates and filtering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f8361aa208327af53bf0ad97a9c34