### PR TITLE
Add UI template tests

### DIFF
--- a/test/mockDom.js
+++ b/test/mockDom.js
@@ -1,0 +1,68 @@
+class MockElement {
+  constructor(tagName) {
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this.attributes = {};
+    this.style = {};
+    this.parentElement = null;
+    this.innerHTML = '';
+  }
+  setAttribute(name, value) { this.attributes[name] = String(value); }
+  getAttribute(name) { return this.attributes[name]; }
+  hasAttribute(name) { return Object.prototype.hasOwnProperty.call(this.attributes, name); }
+  removeAttribute(name) { delete this.attributes[name]; }
+  appendChild(child) { child.parentElement = this; this.children.push(child); }
+  remove() { if (this.parentElement) { const idx = this.parentElement.children.indexOf(this); if (idx >= 0) this.parentElement.children.splice(idx,1); this.parentElement = null; } }
+  cloneNode(deep=true) {
+    const clone = new MockElement(this.tagName);
+    clone.innerHTML = this.innerHTML;
+    for (const [k,v] of Object.entries(this.attributes)) clone.attributes[k] = v;
+    for (const [k,v] of Object.entries(this.style)) clone.style[k] = v;
+    if (deep) this.children.forEach(ch => clone.appendChild(ch.cloneNode(true)));
+    return clone;
+  }
+  querySelectorAll(selector) { return querySelectorAllInternal(this, selector); }
+  querySelector(selector) { const res = this.querySelectorAll(selector); return res[0] || null; }
+}
+
+class MockDocument {
+  constructor(root) { this.root = root; }
+  querySelectorAll(selector) { return querySelectorAllInternal(this.root, selector); }
+}
+
+function querySelectorAllInternal(root, selector) {
+  selector = selector.trim();
+  if (selector.includes(' ')) {
+    const [first, rest] = selector.split(/\s+/, 2);
+    let res = [];
+    querySelectorAllInternal(root, first).forEach(el => {
+      res = res.concat(querySelectorAllInternal(el, rest));
+    });
+    return res;
+  }
+  const conds = [];
+  const regex = /\[([^=\]]+)(?:="?([^\]"]*)"?)?\]/g;
+  let m;
+  while ((m = regex.exec(selector)) !== null) {
+    conds.push({name: m[1], value: m[2]});
+  }
+  const out = [];
+  (function traverse(node){
+    if (node instanceof MockElement) {
+      let ok = true;
+      for (const c of conds) {
+        const val = node.getAttribute(c.name);
+        if (c.value === undefined) {
+          if (val === undefined) { ok = false; break; }
+        } else {
+          if (val !== c.value) { ok = false; break; }
+        }
+      }
+      if (ok) out.push(node);
+    }
+    node.children.forEach(ch => traverse(ch));
+  })(root);
+  return out;
+}
+
+module.exports = { MockElement, MockDocument };

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -1,0 +1,93 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+const { MockElement, MockDocument } = require('./mockDom');
+
+function createResonantDom(root){
+  const code = fs.readFileSync(path.join(__dirname,'..','resonant.js'),'utf8');
+  const context = { console, setTimeout, clearTimeout };
+  context.window = context;
+  context.document = new MockDocument(root);
+  const store = {};
+  context.localStorage = {
+    getItem:key => (key in store? store[key]:null),
+    setItem:(k,v)=>{store[k]=v;},
+    removeItem:k=>{delete store[k];}
+  };
+  vm.createContext(context);
+  vm.runInContext(code,context);
+  const Resonant = vm.runInContext('Resonant',context);
+  return { context, resonant: new Resonant(), root };
+}
+
+test('template updates single value', async () => {
+  const span = new MockElement('span');
+  span.setAttribute('res','item');
+  const root = new MockElement('div');
+  root.appendChild(span);
+
+  const { context, resonant } = createResonantDom(root);
+  resonant.add('item','first');
+  assert.strictEqual(span.innerHTML,'first');
+  context.item = 'second';
+  await new Promise(r=>setTimeout(r,5));
+  assert.strictEqual(span.innerHTML,'second');
+});
+
+test('template updates object property', async () => {
+  const holder = new MockElement('div');
+  holder.setAttribute('res','person');
+  const span = new MockElement('span');
+  span.setAttribute('res-prop','name');
+  holder.appendChild(span);
+  const root = new MockElement('div');
+  root.appendChild(holder);
+
+  const { context, resonant } = createResonantDom(root);
+  resonant.add('person',{name:'John'});
+  assert.strictEqual(span.innerHTML,'John');
+  context.person.name = 'Jane';
+  await new Promise(r=>setTimeout(r,5));
+  assert.strictEqual(span.innerHTML,'Jane');
+});
+
+test('template handles array of values', async () => {
+  const ul = new MockElement('ul');
+  const li = new MockElement('li');
+  li.setAttribute('res','items');
+  const span = new MockElement('span');
+  span.setAttribute('res-prop','');
+  li.appendChild(span);
+  ul.appendChild(li);
+  const root = ul;
+
+  const { context, resonant } = createResonantDom(root);
+  resonant.add('items',['a']);
+  let rendered = ul.querySelector('[res-rendered="true"]');
+  assert.strictEqual(rendered.querySelector('[res-prop=""]').innerHTML,'a');
+  context.items.set(0, 'b');
+  await new Promise(r=>setTimeout(r,5));
+  rendered = ul.querySelector('[res-rendered="true"]');
+  assert.strictEqual(rendered.querySelector('[res-prop=""]').innerHTML,'b');
+});
+
+test('template handles array of objects', async () => {
+  const ul = new MockElement('ul');
+  const li = new MockElement('li');
+  li.setAttribute('res','people');
+  const span = new MockElement('span');
+  span.setAttribute('res-prop','name');
+  li.appendChild(span);
+  ul.appendChild(li);
+  const root = ul;
+
+  const { context, resonant } = createResonantDom(root);
+  resonant.add('people',[{name:'John'}]);
+  const getSpan = () => ul.querySelector('[res-rendered="true"] [res-prop="name"]');
+  assert.strictEqual(getSpan().innerHTML,'John');
+  context.people[0].name = 'Jack';
+  await new Promise(r=>setTimeout(r,5));
+  assert.strictEqual(getSpan().innerHTML,'Jack');
+});


### PR DESCRIPTION
## Summary
- create a lightweight DOM mock for tests
- add tests covering template rendering for primitives, objects, and arrays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f86c8f9448327a2461c39ba369057