### PR TITLE
Add tests for style and click handling

### DIFF
--- a/test/mockDom.js
+++ b/test/mockDom.js
@@ -4,6 +4,12 @@ class MockElement {
     this.children = [];
     this.attributes = {};
     this.style = {};
+    this.classList = {
+      _set: new Set(),
+      add: cls => { this.classList._set.add(cls); },
+      remove: cls => { this.classList._set.delete(cls); },
+      contains: cls => this.classList._set.has(cls)
+    };
     this.parentElement = null;
     this._innerHTML = '';
     this._renderCount = 0;
@@ -46,6 +52,7 @@ class MockElement {
     clone.innerHTML = this.innerHTML;
     for (const [k,v] of Object.entries(this.attributes)) clone.attributes[k] = v;
     for (const [k,v] of Object.entries(this.style)) clone.style[k] = v;
+    for (const cls of this.classList._set) clone.classList.add(cls);
     if (deep) this.children.forEach(ch => clone.appendChild(ch.cloneNode(true)));
     clone.resetRenderTracking(); // Reset tracking for cloned elements
     return clone;
@@ -61,6 +68,13 @@ class MockDocument {
 
 function querySelectorAllInternal(root, selector) {
   selector = selector.trim();
+  if (selector.includes(',')) {
+    let results = [];
+    selector.split(',').forEach(part => {
+      results = results.concat(querySelectorAllInternal(root, part.trim()));
+    });
+    return results;
+  }
   if (selector.includes(' ')) {
     const [first, rest] = selector.split(/\s+/, 2);
     let res = [];

--- a/test/style_and_events.test.js
+++ b/test/style_and_events.test.js
@@ -1,0 +1,93 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+const { MockElement, MockDocument } = require('./mockDom');
+
+function createResonantDom(root) {
+  const code = fs.readFileSync(path.join(__dirname, '..', 'resonant.js'), 'utf8');
+  const context = { console, setTimeout, clearTimeout };
+  context.window = context;
+  context.document = new MockDocument(root);
+  const store = {};
+  context.localStorage = {
+    getItem: key => (key in store ? store[key] : null),
+    setItem: (k, v) => { store[k] = v; },
+    removeItem: k => { delete store[k]; }
+  };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  const Resonant = vm.runInContext('Resonant', context);
+  return { context, resonant: new Resonant(), root };
+}
+
+// Dynamic styling test
+test('res-style updates class based on data changes', async () => {
+  const ul = new MockElement('ul');
+  const li = new MockElement('li');
+  li.setAttribute('res', 'tasks');
+  const status = new MockElement('span');
+  status.setAttribute('res-style', "tasks.completed ? 'done' : ''");
+  li.appendChild(status);
+  ul.appendChild(li);
+  const root = new MockElement('div');
+  root.appendChild(ul);
+
+  const { context, resonant } = createResonantDom(root);
+  resonant.add('tasks', [{ completed: false }]);
+
+  let rendered = ul.querySelector('[res-rendered="true"]');
+  let statusEl = rendered.querySelector('[res-style]');
+  assert.strictEqual(statusEl.classList.contains('done'), false);
+
+  context.tasks[0].completed = true;
+  await new Promise(r => setTimeout(r, 20));
+  rendered = ul.querySelector('[res-rendered="true"]');
+  statusEl = rendered.querySelector('[res-style]');
+  assert.strictEqual(statusEl.classList.contains('done'), true);
+
+  context.tasks[0].completed = false;
+  await new Promise(r => setTimeout(r, 20));
+  rendered = ul.querySelector('[res-rendered="true"]');
+  statusEl = rendered.querySelector('[res-style]');
+  assert.strictEqual(statusEl.classList.contains('done'), false);
+});
+
+// Click handling test
+test('res-onclick and res-onclick-remove trigger correctly', async () => {
+  const ul = new MockElement('ul');
+  const li = new MockElement('li');
+  li.setAttribute('res', 'items');
+  const span = new MockElement('span');
+  span.setAttribute('res-prop', 'name');
+  const selectBtn = new MockElement('button');
+  selectBtn.setAttribute('res-onclick', 'selectItem');
+  const removeBtn = new MockElement('button');
+  removeBtn.setAttribute('res-onclick-remove', 'id');
+  li.appendChild(span);
+  li.appendChild(selectBtn);
+  li.appendChild(removeBtn);
+  ul.appendChild(li);
+  const root = new MockElement('div');
+  root.appendChild(ul);
+
+  const { context, resonant } = createResonantDom(root);
+  context.selectItem = item => { context.selected = item.id; };
+  resonant.add('items', [{ id: 1, name: 'a' }, { id: 2, name: 'b' }]);
+
+  let rendered = ul.querySelectorAll('[res-rendered="true"]');
+  assert.strictEqual(rendered.length, 2);
+
+  rendered[1].querySelector('[res-onclick]').onclick();
+  await new Promise(r => setTimeout(r, 5));
+  assert.strictEqual(context.selected, 2);
+
+  rendered[0].querySelector('[res-onclick-remove]').onclick();
+  await new Promise(r => setTimeout(r, 5));
+
+  assert.strictEqual(context.items.length, 1);
+  assert.strictEqual(context.items[0].id, 2);
+  rendered = ul.querySelectorAll('[res-rendered="true"]');
+  assert.strictEqual(rendered.length, 1);
+});


### PR DESCRIPTION
## Summary
- extend MockElement with basic `classList` support
- allow comma selectors in the mock DOM query implementation
- add `style_and_events.test.js` covering `res-style` and click handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869d24eed9083278f0bfaaf7887dfc4